### PR TITLE
Remove pybind11 from git submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "pybind11"]
-	path = pybind11
-	url = https://github.com/pybind/pybind11
 [submodule "plugins"]
 	path = plugins
 	url = https://github.com/albertlauncher/python.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,9 +3,9 @@ project(python VERSION 6.7)
 
 find_package(Albert REQUIRED)
 
+find_package(pybind11 REQUIRED)
 set(PYBIND11_FINDPYTHON ON)
 #find_package(Python 3.8 COMPONENTS Interpreter Development REQUIRED)
-add_subdirectory(pybind11)
 
 albert_plugin(
     INCLUDE PRIVATE $<TARGET_PROPERTY:albert::applications,INTERFACE_INCLUDE_DIRECTORIES>


### PR DESCRIPTION
According to [Repology](https://repology.org/project/python%3Apybind11/versions), pybind11 has been included in most Linux distros and macOS package managers (Homebrew & MacPorts). Therefore, it is unnecessary to include it in git submodules.