### PR TITLE
Add Recoll full-text search plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -79,3 +79,6 @@
 [submodule "plugins/zeal"]
 	path = plugins/zeal
 	url = https://github.com/albertlauncher/albert-plugin-python-zeal
+[submodule "plugins/recoll"]
+	path = plugins/recoll
+	url = https://github.com/hyiltiz/albert-plugin-python-recoll.git


### PR DESCRIPTION
## Summary

- Adds [recoll](https://github.com/hyiltiz/albert-plugin-python-recoll) as a submodule under `plugins/recoll`
- Provides filename search (`r ` trigger) and full-text content search (`rr ` trigger) via `recollq` CLI
- Queries the on-disk Xapian index maintained by Recoll, without loading any index into memory
- Configurable recollq path (auto-detected on macOS), result limit, debounce interval, and Recoll config directory via Albert settings UI
- MIME-type based icons with category fallback
- 4 actions per result: Open, Open folder, Copy path, Open terminal

## Test plan

- [ ] Enable plugin in Albert Settings
- [ ] `r <query>` returns filename results with path as subtext
- [ ] `rr <query>` returns content results with abstract snippets
- [ ] Actions: Open, Open folder, Copy path, Open terminal
- [ ] recollq auto-detection on macOS
- [ ] Debounce prevents subprocess churn during rapid typing
- [ ] Graceful handling of missing binary, timeout, and no results